### PR TITLE
0.37.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ subprojects {
     apply plugin: 'maven'
 
     group 'org.iot-dsa'
-    version '0.36.1-SNAPSHOT'
+    version '0.37.0'
 
     sourceCompatibility = 1.6
     targetCompatibility = 1.6

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ subprojects {
     apply plugin: 'maven'
 
     group 'org.iot-dsa'
-    version '0.36.0'
+    version '0.36.1-SNAPSHOT'
 
     sourceCompatibility = 1.6
     targetCompatibility = 1.6

--- a/dslink-v2/src/main/java/com/acuity/iot/dsa/dslink/sys/profiler/ClassLoadingNode.java
+++ b/dslink-v2/src/main/java/com/acuity/iot/dsa/dslink/sys/profiler/ClassLoadingNode.java
@@ -2,7 +2,6 @@ package com.acuity.iot.dsa.dslink.sys.profiler;
 
 import java.lang.management.ClassLoadingMXBean;
 import java.lang.management.ManagementFactory;
-import java.lang.management.PlatformManagedObject;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -20,12 +19,12 @@ public class ClassLoadingNode extends MXBeanNode {
     }
 
     @Override
-    public PlatformManagedObject getMXBean() {
+    public Object getMXBean() {
         return mxbean;
     }
 
     @Override
-    public Class<? extends PlatformManagedObject> getMXInterface() {
+    public Class<? extends Object> getMXInterface() {
         return ClassLoadingMXBean.class;
     }
 

--- a/dslink-v2/src/main/java/com/acuity/iot/dsa/dslink/sys/profiler/CompilationNode.java
+++ b/dslink-v2/src/main/java/com/acuity/iot/dsa/dslink/sys/profiler/CompilationNode.java
@@ -2,7 +2,6 @@ package com.acuity.iot.dsa.dslink.sys.profiler;
 
 import java.lang.management.CompilationMXBean;
 import java.lang.management.ManagementFactory;
-import java.lang.management.PlatformManagedObject;
 import java.util.ArrayList;
 import java.util.List;
 import org.iot.dsa.node.DSString;
@@ -23,12 +22,12 @@ public class CompilationNode extends MXBeanNode {
     }
 
     @Override
-    public PlatformManagedObject getMXBean() {
+    public Object getMXBean() {
         return mxbean;
     }
 
     @Override
-    public Class<? extends PlatformManagedObject> getMXInterface() {
+    public Class<? extends Object> getMXInterface() {
         return CompilationMXBean.class;
     }
 

--- a/dslink-v2/src/main/java/com/acuity/iot/dsa/dslink/sys/profiler/GarbageCollectorNode.java
+++ b/dslink-v2/src/main/java/com/acuity/iot/dsa/dslink/sys/profiler/GarbageCollectorNode.java
@@ -1,7 +1,6 @@
 package com.acuity.iot.dsa.dslink.sys.profiler;
 
 import java.lang.management.GarbageCollectorMXBean;
-import java.lang.management.PlatformManagedObject;
 import java.util.ArrayList;
 import java.util.List;
 import org.iot.dsa.node.DSString;
@@ -31,12 +30,12 @@ public class GarbageCollectorNode extends MXBeanNode {
     }
 
     @Override
-    public PlatformManagedObject getMXBean() {
+    public Object getMXBean() {
         return mxbean;
     }
 
     @Override
-    public Class<? extends PlatformManagedObject> getMXInterface() {
+    public Class<? extends Object> getMXInterface() {
         return GarbageCollectorMXBean.class;
     }
 

--- a/dslink-v2/src/main/java/com/acuity/iot/dsa/dslink/sys/profiler/MXBeanNode.java
+++ b/dslink-v2/src/main/java/com/acuity/iot/dsa/dslink/sys/profiler/MXBeanNode.java
@@ -3,6 +3,8 @@ package com.acuity.iot.dsa.dslink.sys.profiler;
 import java.lang.management.PlatformManagedObject;
 import java.lang.reflect.Method;
 import java.util.List;
+import org.iot.dsa.DSRuntime;
+import org.iot.dsa.DSRuntime.Timer;
 import org.iot.dsa.node.DSIObject;
 import org.iot.dsa.node.DSInfo;
 import org.iot.dsa.node.DSNode;
@@ -11,7 +13,9 @@ import org.iot.dsa.node.action.ActionInvocation;
 import org.iot.dsa.node.action.ActionResult;
 import org.iot.dsa.node.action.DSAction;
 
-public abstract class MXBeanNode extends DSNode {
+public abstract class MXBeanNode extends DSNode implements Runnable {
+    
+    private Timer pollTimer;
 
     private static DSAction refreshAction = new DSAction() {
         @Override
@@ -31,6 +35,23 @@ public abstract class MXBeanNode extends DSNode {
     protected void onStable() {
         setupMXBean();
         refresh();
+        setupPolling();
+    }
+
+    private void setupPolling() {
+        pollTimer = DSRuntime.run(this, 0, 5000);
+    }
+    
+    @Override
+    public void run() {
+        if (isTreeSubscribed()) {
+            refresh();
+        }
+    }
+    
+    @Override
+    protected void onStopped() {
+        pollTimer.cancel();
     }
 
     private void refresh() {
@@ -78,5 +99,7 @@ public abstract class MXBeanNode extends DSNode {
     protected void putProp(String name, DSIObject obj) {
         put(name, obj).setReadOnly(true).setTransient(true);
     }
+    
+    
 
 }

--- a/dslink-v2/src/main/java/com/acuity/iot/dsa/dslink/sys/profiler/MXBeanNode.java
+++ b/dslink-v2/src/main/java/com/acuity/iot/dsa/dslink/sys/profiler/MXBeanNode.java
@@ -1,5 +1,6 @@
 package com.acuity.iot.dsa.dslink.sys.profiler;
 
+import java.lang.management.MemoryPoolMXBean;
 import java.lang.reflect.Method;
 import java.util.List;
 import org.iot.dsa.DSRuntime;
@@ -88,7 +89,11 @@ public abstract class MXBeanNode extends DSNode implements Runnable {
                         putProp(name,
                                 o != null ? ProfilerUtils.objectToDSIValue(o) : DSString.EMPTY);
                     } catch (Exception e) {
-                        debug(e);
+                        if (bean instanceof MemoryPoolMXBean && (name.startsWith("UsageThreshold") || name.startsWith("CollectionUsageThreshold"))) {
+                            // ignore
+                        } else {
+                            debug("Exception when invoking " + clazz.getName() + "." + meth.getName() + " on " + getName() + ": ", e);
+                        }
                     }
                 }
             }
@@ -98,7 +103,4 @@ public abstract class MXBeanNode extends DSNode implements Runnable {
     protected void putProp(String name, DSIObject obj) {
         put(name, obj).setReadOnly(true).setTransient(true);
     }
-    
-    
-
 }

--- a/dslink-v2/src/main/java/com/acuity/iot/dsa/dslink/sys/profiler/MXBeanNode.java
+++ b/dslink-v2/src/main/java/com/acuity/iot/dsa/dslink/sys/profiler/MXBeanNode.java
@@ -1,6 +1,5 @@
 package com.acuity.iot.dsa.dslink.sys.profiler;
 
-import java.lang.management.PlatformManagedObject;
 import java.lang.reflect.Method;
 import java.util.List;
 import org.iot.dsa.DSRuntime;
@@ -63,15 +62,15 @@ public abstract class MXBeanNode extends DSNode implements Runnable {
 
     public abstract void refreshImpl();
 
-    public abstract PlatformManagedObject getMXBean();
+    public abstract Object getMXBean();
 
-    public abstract Class<? extends PlatformManagedObject> getMXInterface();
+    public abstract Class<? extends Object> getMXInterface();
 
     public abstract List<String> getOverriden();
 
     public void discover() {
-        PlatformManagedObject bean = getMXBean();
-        Class<? extends PlatformManagedObject> clazz = getMXInterface();
+        Object bean = getMXBean();
+        Class<? extends Object> clazz = getMXInterface();
         for (Method meth : clazz.getMethods()) {
             String methName = meth.getName();
             if (meth.getParameterCount() == 0 && meth.getReturnType() != Void.TYPE) {

--- a/dslink-v2/src/main/java/com/acuity/iot/dsa/dslink/sys/profiler/MemoryManagerNode.java
+++ b/dslink-v2/src/main/java/com/acuity/iot/dsa/dslink/sys/profiler/MemoryManagerNode.java
@@ -1,7 +1,6 @@
 package com.acuity.iot.dsa.dslink.sys.profiler;
 
 import java.lang.management.MemoryManagerMXBean;
-import java.lang.management.PlatformManagedObject;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -30,12 +29,12 @@ public class MemoryManagerNode extends MXBeanNode {
     }
 
     @Override
-    public PlatformManagedObject getMXBean() {
+    public Object getMXBean() {
         return mxbean;
     }
 
     @Override
-    public Class<? extends PlatformManagedObject> getMXInterface() {
+    public Class<? extends Object> getMXInterface() {
         return MemoryManagerMXBean.class;
     }
 

--- a/dslink-v2/src/main/java/com/acuity/iot/dsa/dslink/sys/profiler/MemoryNode.java
+++ b/dslink-v2/src/main/java/com/acuity/iot/dsa/dslink/sys/profiler/MemoryNode.java
@@ -2,7 +2,6 @@ package com.acuity.iot.dsa.dslink.sys.profiler;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
-import java.lang.management.PlatformManagedObject;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -21,12 +20,12 @@ public class MemoryNode extends MXBeanNode {
     }
 
     @Override
-    public PlatformManagedObject getMXBean() {
+    public Object getMXBean() {
         return mxbean;
     }
 
     @Override
-    public Class<? extends PlatformManagedObject> getMXInterface() {
+    public Class<? extends Object> getMXInterface() {
         return MemoryMXBean.class;
     }
 

--- a/dslink-v2/src/main/java/com/acuity/iot/dsa/dslink/sys/profiler/MemoryPoolNode.java
+++ b/dslink-v2/src/main/java/com/acuity/iot/dsa/dslink/sys/profiler/MemoryPoolNode.java
@@ -24,8 +24,6 @@ public class MemoryPoolNode extends MXBeanNode {
 
     @Override
     public void refreshImpl() {
-        // TODO Auto-generated method stub
-
     }
 
     @Override

--- a/dslink-v2/src/main/java/com/acuity/iot/dsa/dslink/sys/profiler/MemoryPoolNode.java
+++ b/dslink-v2/src/main/java/com/acuity/iot/dsa/dslink/sys/profiler/MemoryPoolNode.java
@@ -1,7 +1,6 @@
 package com.acuity.iot.dsa.dslink.sys.profiler;
 
 import java.lang.management.MemoryPoolMXBean;
-import java.lang.management.PlatformManagedObject;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -30,12 +29,12 @@ public class MemoryPoolNode extends MXBeanNode {
     }
 
     @Override
-    public PlatformManagedObject getMXBean() {
+    public Object getMXBean() {
         return mxbean;
     }
 
     @Override
-    public Class<? extends PlatformManagedObject> getMXInterface() {
+    public Class<? extends Object> getMXInterface() {
         return MemoryPoolMXBean.class;
     }
 

--- a/dslink-v2/src/main/java/com/acuity/iot/dsa/dslink/sys/profiler/OperatingSystemNode.java
+++ b/dslink-v2/src/main/java/com/acuity/iot/dsa/dslink/sys/profiler/OperatingSystemNode.java
@@ -2,7 +2,6 @@ package com.acuity.iot.dsa.dslink.sys.profiler;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
-import java.lang.management.PlatformManagedObject;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -22,12 +21,12 @@ public class OperatingSystemNode extends MXBeanNode {
     }
 
     @Override
-    public PlatformManagedObject getMXBean() {
+    public Object getMXBean() {
         return mxbean;
     }
 
     @Override
-    public Class<? extends PlatformManagedObject> getMXInterface() {
+    public Class<? extends Object> getMXInterface() {
         return OperatingSystemMXBean.class;
     }
 

--- a/dslink-v2/src/main/java/com/acuity/iot/dsa/dslink/sys/profiler/RuntimeNode.java
+++ b/dslink-v2/src/main/java/com/acuity/iot/dsa/dslink/sys/profiler/RuntimeNode.java
@@ -1,7 +1,6 @@
 package com.acuity.iot.dsa.dslink.sys.profiler;
 
 import java.lang.management.ManagementFactory;
-import java.lang.management.PlatformManagedObject;
 import java.lang.management.RuntimeMXBean;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -46,12 +45,12 @@ public class RuntimeNode extends MXBeanNode {
     }
 
     @Override
-    public PlatformManagedObject getMXBean() {
+    public Object getMXBean() {
         return mxbean;
     }
 
     @Override
-    public Class<? extends PlatformManagedObject> getMXInterface() {
+    public Class<? extends Object> getMXInterface() {
         return RuntimeMXBean.class;
     }
 

--- a/dslink-v2/src/main/java/com/acuity/iot/dsa/dslink/sys/profiler/SysProfiler.java
+++ b/dslink-v2/src/main/java/com/acuity/iot/dsa/dslink/sys/profiler/SysProfiler.java
@@ -41,5 +41,10 @@ public class SysProfiler extends DSNode {
             mpNode.put(mxbean.getName(), new MemoryPoolNode(mxbean)).setTransient(true);
         }
     }
+    
+    @Override
+    public String getLogName() {
+        return getLogName("profiler");
+    }
 
 }

--- a/dslink-v2/src/main/java/com/acuity/iot/dsa/dslink/sys/profiler/SysProfiler.java
+++ b/dslink-v2/src/main/java/com/acuity/iot/dsa/dslink/sys/profiler/SysProfiler.java
@@ -15,15 +15,15 @@ public class SysProfiler extends DSNode {
     @Override
     protected void declareDefaults() {
         super.declareDefaults();
-        declareDefault("Runtime", new RuntimeNode());
-        declareDefault("Class Loading", new ClassLoadingNode());
-        declareDefault("Compilation", new CompilationNode());
-        declareDefault("Memory", new MemoryNode());
-        declareDefault("Operating System", new OperatingSystemNode());
-        declareDefault("Thread", new ThreadNode());
-        declareDefault("Garbage Collectors", new DSNode());
-        declareDefault("Memory Managers", new DSNode());
-        declareDefault("Memory Pools", new DSNode());
+        declareDefault("Runtime", new RuntimeNode()).setTransient(true);
+        declareDefault("Class Loading", new ClassLoadingNode()).setTransient(true);
+        declareDefault("Compilation", new CompilationNode()).setTransient(true);
+        declareDefault("Memory", new MemoryNode()).setTransient(true);
+        declareDefault("Operating System", new OperatingSystemNode()).setTransient(true);
+        declareDefault("Thread", new ThreadNode()).setTransient(true);
+        declareDefault("Garbage Collectors", new DSNode()).setTransient(true);
+        declareDefault("Memory Managers", new DSNode()).setTransient(true);
+        declareDefault("Memory Pools", new DSNode()).setTransient(true);
     }
 
     @Override

--- a/dslink-v2/src/main/java/com/acuity/iot/dsa/dslink/sys/profiler/ThreadNode.java
+++ b/dslink-v2/src/main/java/com/acuity/iot/dsa/dslink/sys/profiler/ThreadNode.java
@@ -1,7 +1,6 @@
 package com.acuity.iot.dsa.dslink.sys.profiler;
 
 import java.lang.management.ManagementFactory;
-import java.lang.management.PlatformManagedObject;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 import java.util.*;
@@ -160,12 +159,12 @@ public class ThreadNode extends MXBeanNode {
     }
 
     @Override
-    public PlatformManagedObject getMXBean() {
+    public Object getMXBean() {
         return mxbean;
     }
 
     @Override
-    public Class<? extends PlatformManagedObject> getMXInterface() {
+    public Class<? extends Object> getMXInterface() {
         return ThreadMXBean.class;
     }
 

--- a/dslink-v2/src/test/java/org/iot/dsa/dslink/SysProfilerTest.java
+++ b/dslink-v2/src/test/java/org/iot/dsa/dslink/SysProfilerTest.java
@@ -1,0 +1,88 @@
+package org.iot.dsa.dslink;
+
+import org.iot.dsa.conn.DSConnection.DSConnectionEvent;
+import org.iot.dsa.dslink.requester.SimpleInvokeHandler;
+import org.iot.dsa.node.DSIObject;
+import org.iot.dsa.node.DSInfo;
+import org.iot.dsa.node.DSNode;
+import org.iot.dsa.node.event.DSIEvent;
+import org.iot.dsa.node.event.DSISubscriber;
+import org.iot.dsa.node.event.DSTopic;
+import org.junit.Assert;
+import org.junit.Test;
+import com.acuity.iot.dsa.dslink.sys.profiler.SysProfiler;
+import com.acuity.iot.dsa.dslink.sys.profiler.ThreadNode;
+import com.acuity.iot.dsa.dslink.test.TestLink;
+
+public class SysProfilerTest {
+    
+    private static boolean success = false;
+    private DSLink link;
+    
+    @Test
+    public void theTest() throws Exception {
+        link = new TestLink(new DSMainNode());
+        link.getConnection().subscribe(DSLinkConnection.CONN_TOPIC, new DSISubscriber() {
+            @Override
+            public void onEvent(DSNode node, DSInfo child, DSIEvent event) {
+                if (event == DSConnectionEvent.CONNECTED) {
+                    success = true;
+                    synchronized (SysProfilerTest.this) {
+                        SysProfilerTest.this.notifyAll();
+                    }
+                }
+            }
+
+            @Override
+            public void onUnsubscribed(DSTopic topic, DSNode node, DSInfo child) {
+            }
+        });
+        success = false;
+        Thread t = new Thread(link, "DSLink Runner");
+        t.start();
+        synchronized (this) {
+            this.wait(5000);
+        }
+        Assert.assertTrue(success);
+        success = false;
+        DSIRequester requester = link.getConnection().getRequester();
+        SimpleInvokeHandler res = (SimpleInvokeHandler) requester.invoke(
+                "/sys/" + DSSysNode.OPEN_PROFILER, null, new SimpleInvokeHandler());
+        res.getResult(1000);
+        
+        DSSysNode sys = link.getSys();
+        DSIObject profobj = sys.get(DSSysNode.PROFILER);
+        Assert.assertTrue(profobj instanceof SysProfiler);
+        
+        SysProfiler profiler = (SysProfiler) profobj;
+        DSIObject threadobj = profiler.get("Thread");
+        Assert.assertTrue(threadobj instanceof ThreadNode);
+        
+        final ThreadNode thread = (ThreadNode) threadobj;
+        final DSInfo cpuTime = thread.getInfo("CurrentThreadCpuTime");
+        Assert.assertTrue(cpuTime != null);
+        thread.subscribe(DSNode.VALUE_TOPIC, cpuTime, new DSISubscriber() {
+            
+            @Override
+            public void onUnsubscribed(DSTopic topic, DSNode node, DSInfo child) {
+            }
+            
+            @Override
+            public void onEvent(DSNode node, DSInfo child, DSIEvent event) {
+                Assert.assertEquals(thread, node);
+                Assert.assertEquals(cpuTime, child);
+                Assert.assertTrue(child.isValue());
+                Assert.assertTrue(child.getValue().toElement().isNumber());
+                success = true;
+                synchronized (SysProfilerTest.this) {
+                    SysProfilerTest.this.notifyAll();
+                }
+            }
+        });
+        synchronized (this) {
+            this.wait(6000);
+        }
+        Assert.assertTrue(success);
+    }
+
+}


### PR DESCRIPTION
- Add "Open Profiler" and "Close Profiler" actions to sys node to add/remove the profiler node
- Set Profiler to auto-refresh subscribed properties on a 5 second interval
- Add "Get Thread Dump" action to sys/Profiler/Thread, which returns a full thread dump
- Remove dependency on Java 1.7 (by removing references to PlatformManagedObject)
- Suppress expected InvocationTargetExceptions during profiler setup
- Add unit test for basic profiler features