### PR TITLE
0.75.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ subprojects {
     apply plugin: 'maven'
 
     group 'org.iot-dsa'
-    version '0.74.1'
+    version '0.75.0'
 
     targetCompatibility = JavaVersion.VERSION_1_8
     sourceCompatibility = JavaVersion.VERSION_1_8

--- a/dslink-v2-api/src/main/java/org/iot/dsa/node/DSInfo.java
+++ b/dslink-v2-api/src/main/java/org/iot/dsa/node/DSInfo.java
@@ -35,6 +35,7 @@ public class DSInfo<T extends DSIObject> implements GroupListener {
     static final int DECLARED = 4;
     static final int DEFAULT_ON_COPY = 5;
     static final int LOCKED = 6;
+    static final int IGNORE_EQUALS = 7;
 
     ///////////////////////////////////////////////////////////////////////////
     // Fields
@@ -329,6 +330,23 @@ public class DSInfo<T extends DSIObject> implements GroupListener {
      */
     public boolean isFrozen() {
         return isDeclared() || isLocked();
+    }
+
+    /**
+     * False by default, set to true if you don't want equals objects to be applied and
+     * events to be fired.
+     */
+    public boolean isIgnoreEquals() {
+        return getFlag(IGNORE_EQUALS);
+    }
+
+    /**
+     * False by default, set to true if you don't want equals objects to be applied and
+     * events to be fired.
+     */
+    public DSInfo<T> setIgnoreEquals(boolean ignore) {
+        setFlag(IGNORE_EQUALS, ignore);
+        return this;
     }
 
     /**

--- a/dslink-v2-api/src/main/java/org/iot/dsa/node/DSNode.java
+++ b/dslink-v2-api/src/main/java/org/iot/dsa/node/DSNode.java
@@ -904,6 +904,10 @@ public class DSNode extends DSLogger implements DSIObject, Iterable<DSInfo<?>> {
             throw new IllegalArgumentException("Info parented in another node");
         }
         validateChild(object);
+        DSIObject old = info.get();
+        if (DSUtil.equal(object, old) && info.isIgnoreEquals()) {
+            return this;
+        }
         DSNode argAsNode = null;
         boolean argIsNode = isNode(object);
         if (argIsNode) {
@@ -913,7 +917,6 @@ public class DSNode extends DSLogger implements DSIObject, Iterable<DSInfo<?>> {
         if (object instanceof DSGroup) {
             ((DSGroup) object).setParent(this);
         }
-        DSIObject old = info.get();
         ((DSInfo<DSIObject>) info).setObject(object);
         if (isNode(old)) {
             DSNode node = toNode(old);

--- a/dslink-v2/src/main/java/com/acuity/iot/dsa/dslink/protocol/responder/DSInboundList.java
+++ b/dslink-v2/src/main/java/com/acuity/iot/dsa/dslink/protocol/responder/DSInboundList.java
@@ -105,6 +105,12 @@ public class DSInboundList extends DSInboundRequest
         return state.isOpen();
     }
 
+    @Override
+    public void listComplete() {
+        sendStreamOpen = true;
+        enqueueResponse();
+    }
+
     /**
      * This is the only way to really close a list request, called only when the connection is
      * closed or the requester has explicitly closed it.
@@ -269,12 +275,6 @@ public class DSInboundList extends DSInboundRequest
             }
         }
         enqueue(encodeName(name, cacheBuf), map);
-    }
-
-    @Override
-    public void listComplete() {
-        sendStreamOpen = true;
-        enqueueResponse();
     }
 
     @Override

--- a/dslink-v2/src/main/java/com/acuity/iot/dsa/dslink/transport/DSTransport.java
+++ b/dslink-v2/src/main/java/com/acuity/iot/dsa/dslink/transport/DSTransport.java
@@ -26,7 +26,7 @@ public abstract class DSTransport extends DSNode implements DSITransport {
     // Class Fields
     ///////////////////////////////////////////////////////////////////////////
 
-    private static final int DEFAULT_READ_TIMEOUT = 60000;
+    private static final int DEFAULT_READ_TIMEOUT = 90000;
     private static final byte[] EMPTY_BYTES = new byte[0];
     private static final int HEX_COLS = 30;
     private static final String TEXT = "Text";
@@ -463,6 +463,12 @@ public abstract class DSTransport extends DSNode implements DSITransport {
     protected void onStarted() {
         super.onStarted();
         getTransportLogger();
+    }
+
+    @Override
+    protected void onStopped() {
+        close();
+        super.onStopped();
     }
 
     /**

--- a/dslink-v2/src/test/java/org/iot/dsa/dslink/DSRuntimeTest.java
+++ b/dslink-v2/src/test/java/org/iot/dsa/dslink/DSRuntimeTest.java
@@ -29,10 +29,6 @@ public class DSRuntimeTest {
                 }
             }
         }, System.currentTimeMillis() + 400, 100);
-
-//        System.out.println("test1    now: " + System.nanoTime());
-//        System.out.println("test1nextrun: " + tim.nextRun());
-
         synchronized (lock1) {
             lock1.wait(1000);
         }
@@ -50,10 +46,6 @@ public class DSRuntimeTest {
                 }
             }
         }, 400, 100);
-
-//        System.out.println("test2    now: " + System.nanoTime());
-//        System.out.println("test2nextrun: " + tim.nextRun());
-
         synchronized (lock2) {
             lock2.wait(1000);
         }
@@ -69,10 +61,6 @@ public class DSRuntimeTest {
                 lock3.notifyAll();
             }
         }, System.currentTimeMillis() + 400);
-
-//        System.out.println("test3    now: " + System.nanoTime());
-//        System.out.println("test3nextrun: " + tim.nextRun());
-
         synchronized (lock3) {
             lock3.wait(500);
         }
@@ -88,10 +76,6 @@ public class DSRuntimeTest {
                 lock4.notifyAll();
             }
         }, 400);
-
-//        System.out.println("test4    now: " + System.nanoTime());
-//        System.out.println("test4nextrun: " + tim.nextRun());
-
         synchronized (lock4) {
             lock4.wait(500);
         }
@@ -109,14 +93,14 @@ public class DSRuntimeTest {
                 }
             }
         }, 0, 100);
-
-//        System.out.println("test1    now: " + System.nanoTime());
-//        System.out.println("test1nextrun: " + tim.nextRun());
-
         synchronized (lock5) {
             lock5.wait(600);
         }
         Assert.assertTrue(runsImmed >= 5);
+    }
+
+    @Test
+    public void test6() throws Exception {
     }
 
 }

--- a/dslink-v2/src/test/java/org/iot/dsa/dslink/DSRuntimeTest.java
+++ b/dslink-v2/src/test/java/org/iot/dsa/dslink/DSRuntimeTest.java
@@ -30,7 +30,7 @@ public class DSRuntimeTest {
             }
         }, System.currentTimeMillis() + 400, 100);
         synchronized (lock1) {
-            lock1.wait(1000);
+            lock1.wait(2000);
         }
         Assert.assertTrue(runs >= 5);
     }
@@ -47,7 +47,7 @@ public class DSRuntimeTest {
             }
         }, 400, 100);
         synchronized (lock2) {
-            lock2.wait(1000);
+            lock2.wait(2000);
         }
         Assert.assertTrue(runsWithDelay >= 5);
     }

--- a/dslink-v2/src/test/java/org/iot/dsa/dslink/NodeTest.java
+++ b/dslink-v2/src/test/java/org/iot/dsa/dslink/NodeTest.java
@@ -26,6 +26,27 @@ public class NodeTest {
     // -------
 
     @Test
+    public void testOnChildChanged() throws Exception {
+        DSNode root = new DSNode();
+        MyNode child = new MyNode();
+        root.add("child", child);
+        root.start();
+        Assert.assertTrue(child.isRunning());
+        Assert.assertFalse(child.isStopped());
+        Assert.assertTrue(child.lastChildChange == 0);
+        long time = System.currentTimeMillis();
+        child.setSecond(false);
+        Assert.assertTrue(child.lastChildChange >= time);
+        root.remove("child");
+        Assert.assertFalse(child.isRunning());
+        Assert.assertTrue(child.isStopped());
+        Thread.sleep(10);
+        time = System.currentTimeMillis();
+        child.setSecond(true);
+        Assert.assertFalse(child.lastChildChange >= time);
+    }
+
+    @Test
     public void theTest() {
         testMine(new MyNode());
         testMine(new MyNode()); //on purpose, making sure defaults hold
@@ -60,6 +81,7 @@ public class NodeTest {
 
     public static class MyNode extends DSNode {
 
+        long lastChildChange;
         private DSInfo<?> second = getInfo("second");
 
         public boolean isSecond() {
@@ -74,6 +96,10 @@ public class NodeTest {
         protected void declareDefaults() {
             add("first", DSInt.valueOf(1));
             declareDefault("second", DSBool.valueOf(true));
+        }
+
+        protected void onChildChanged(DSInfo<?> child) {
+            lastChildChange = System.currentTimeMillis();
         }
 
     }

--- a/dslink-v2/src/test/java/org/iot/dsa/dslink/SubscriptionTest.java
+++ b/dslink-v2/src/test/java/org/iot/dsa/dslink/SubscriptionTest.java
@@ -1,0 +1,54 @@
+package org.iot.dsa.dslink;
+
+import com.acuity.iot.dsa.dslink.test.V1TestLink;
+import org.iot.dsa.node.DSInt;
+import org.iot.dsa.node.DSNode;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class SubscriptionTest {
+
+    private static boolean success = false;
+    private V1TestLink link;
+
+    @Test
+    public void theTest() throws Exception {
+        link = new V1TestLink(new DSMainNode());
+        Thread t = new Thread(link, "DSLink Runner");
+        t.start();
+        link.getConnection().waitForConnection(5000);
+        Assert.assertTrue(link.getConnection().isConnected());
+
+        DSMainNode main = link.getMain();
+        main.put("yesDuplicates", DSInt.valueOf(0));
+        main.put("noDuplicates", DSInt.valueOf(0)).setIgnoreEquals(true);
+
+        main.subscribe((event, node, child, data) -> {
+            Assert.assertTrue(child.isValue());
+            Assert.assertTrue(child.getValue().toElement().isNumber());
+            synchronized (SubscriptionTest.this) {
+                success = !success;
+                Assert.assertEquals(node, main);
+                SubscriptionTest.this.notifyAll();
+            }
+        }, DSNode.VALUE_CHANGED_EVENT, null);
+
+        success = false;
+        main.put("yesDuplicates", DSInt.valueOf(0));
+        synchronized (SubscriptionTest.this) {
+            if (!success) {
+                SubscriptionTest.this.wait(5000);
+            }
+        }
+        Assert.assertTrue(success);
+        success = true;
+        main.put("noDuplicates", DSInt.valueOf(0));
+        synchronized (SubscriptionTest.this) {
+            if (success) { //should have to wait
+                SubscriptionTest.this.wait(3000);
+            }
+        }
+        Assert.assertTrue(success);
+    }
+
+}

--- a/dslink-v2/src/test/java/org/iot/dsa/dslink/SysProfilerTest.java
+++ b/dslink-v2/src/test/java/org/iot/dsa/dslink/SysProfilerTest.java
@@ -24,7 +24,7 @@ public class SysProfilerTest {
         DSIRequester requester = link.getConnection().getRequester();
         SimpleInvokeHandler res = (SimpleInvokeHandler) requester.invoke(
                 "/sys/" + DSSysNode.OPEN_PROFILER, null, new SimpleInvokeHandler());
-        res.getUpdate(2000);
+        res.getUpdate(5000);
 
         DSSysNode sys = link.get(DSLink.SYS);
         DSIObject profobj = sys.get(DSSysNode.PROFILER);

--- a/dslink-v2/src/test/java/org/iot/dsa/dslink/SysProfilerTest.java
+++ b/dslink-v2/src/test/java/org/iot/dsa/dslink/SysProfilerTest.java
@@ -7,13 +7,11 @@ import com.acuity.iot.dsa.dslink.test.V1TestLink;
 import org.iot.dsa.dslink.requester.SimpleInvokeHandler;
 import org.iot.dsa.node.DSIObject;
 import org.iot.dsa.node.DSInfo;
-import org.iot.dsa.node.DSNode;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class SysProfilerTest {
 
-    private static boolean success = false;
     private V1TestLink link;
 
     @Test
@@ -39,23 +37,6 @@ public class SysProfilerTest {
         final ThreadNode thread = (ThreadNode) threadobj;
         final DSInfo<?> cpuTime = thread.getInfo("CurrentThreadCpuTime");
         Assert.assertTrue(cpuTime != null);
-        success = false;
-        thread.subscribe((event, node, child, data) -> {
-            Assert.assertEquals(thread, node);
-            Assert.assertEquals(cpuTime, child);
-            Assert.assertTrue(child.isValue());
-            Assert.assertTrue(child.getValue().toElement().isNumber());
-            synchronized (SysProfilerTest.this) {
-                success = true;
-                SysProfilerTest.this.notifyAll();
-            }
-        }, DSNode.VALUE_CHANGED_EVENT, cpuTime);
-        synchronized (this) {
-            if (!success) {
-                this.wait(6000);
-            }
-        }
-        Assert.assertTrue(success);
     }
 
 }


### PR DESCRIPTION
* Add ignore equals flag to dsinfo for ignoring the putting of equals children.
* Extend read timeout to fix random disconnects (timing too tight).
* Close transport on stopped.